### PR TITLE
correcting Pan's affiliation (full name was there twice)

### DIFF
--- a/researchers.html
+++ b/researchers.html
@@ -158,7 +158,7 @@
                                             <h3>Pan Li</h3>
                                             <p><strong>Assistant Professor</strong>
                                             <br>Department of Computer Science 
-                                            <br>Pan Li</p>
+                                            <br>Purdue University</p>
                                             <p><strong>Interest areas:</strong> Hardware and Algorithm</p>
                                          </article>
 


### PR DESCRIPTION
Pan's full name was appearing where his affiliation should be; went ahead and added Purdue U (hope this is correct)