### PR TITLE
Updated events page with scheduled seminars and committee

### DIFF
--- a/events.html
+++ b/events.html
@@ -68,13 +68,35 @@
 						<p>We use a powerful event (meetings, conferences, lectures) management system developed at
 							CERN: <a href="https://indico.cern.ch/category/14395/">Indico.</a>
 
-						<h2>A3D3 Colloquia</h2>
-						<p>We are organizing a series of talks featuring leaders at the intersection of AI and science
-							and engineering. It is tentatively scheduled at 12pm (PDT) in the first week of each month.
-							Detailed agenda will be announced soon.
+						<h2>A3D3 Seminars</h2>
+						<p>We have organized a series of talks featuring leaders at the intersection of AI and science
+							and engineering. Talks are tentatively scheduled at 12pm (PDT).
+							Below is the planned agenda for 2023:
+						<ul>
+							<li>Apr 17th (MMA)
+							<li>May 8 (Neuro)
+							<li>June 12 (HEP)
+							<li>July 10 (Disinguished)
+							<li>August 14 (HVAC) 
+							<li>Sept 11 (General)
+						</ul>
+						</p>
+						<p>
+							The members of the Seminar Committee are:
+						<ul>
+							<li>Matthew Graham (Education co-lead)
+							<li>Kate Scholberg (Education co-lead)
+							<li>Vladimir Loncar (A3D3 scientist)
+							<li>Daniel Diaz (HEP)
+							<li>Hanchen Ye (HCAD)
+							<li>Brian Healy (MMA)
+							<li>Amy Orsbourn (Neuro)
+						</ul>
 						</p>
 
-						<h2>A3D3 pre-kick-off Workshops</h2>
+						<h2>Past Events</h2>
+
+						<h3>A3D3 pre-kick-off Workshops</h3>
 						<ul>
 							<li>Oct 11 2021 "Machine Learning in the Multi-Messenger Era", Michael Coughlin (UMN) <a
 									href="https://indico.cern.ch/event/1085789/">indico</a>
@@ -93,7 +115,7 @@
 								</ul>
 						</ul>
 
-						<h2>A3D3 Institute Events</h2>
+						<h3>Kick-off Meeting</h3>
 						<ul>
 							<li> Nov 8-10 2021 "A3D3 Kick-off meeting", <a
 									href="https://indico.cern.ch/event/1092699/">Indico</a>

--- a/events.html
+++ b/events.html
@@ -76,8 +76,8 @@
 							<li>Apr 17th (MMA)
 							<li>May 8 (Neuro)
 							<li>June 12 (HEP)
-							<li>July 10 (Disinguished)
-							<li>August 14 (HVAC) 
+							<li>July 10 (Distinguished)
+							<li>August 14 (HAC) 
 							<li>Sept 11 (General)
 						</ul>
 						</p>
@@ -88,7 +88,7 @@
 							<li>Kate Scholberg (Education co-lead)
 							<li>Vladimir Loncar (A3D3 scientist)
 							<li>Daniel Diaz (HEP)
-							<li>Hanchen Ye (HCAD)
+							<li>Hanchen Ye (HAC)
 							<li>Brian Healy (MMA)
 							<li>Amy Orsbourn (Neuro)
 						</ul>


### PR DESCRIPTION
Per Matthew Graham's request, this PR updates the Events page with the 2023 seminar schedule and committee members. It also creates a new "Past Events" section under which contains the page's existing info from the pre-kickoff and kickoff events.