### PR TITLE
Add seminar speaker names

### DIFF
--- a/events.html
+++ b/events.html
@@ -73,9 +73,9 @@
 							and engineering. Talks are tentatively scheduled at 12pm (PDT).
 							Below is the planned agenda for 2023:
 						<ul>
-							<li>Apr 17th (MMA)
+							<li>Apr 17th: Niharika Sravan (MMA)
 							<li>May 8 (Neuro)
-							<li>June 12 (HEP)
+							<li>June 12: Thea Aarrestad (HEP)
 							<li>July 10 (Distinguished)
 							<li>August 14 (HAC) 
 							<li>Sept 11 (General)


### PR DESCRIPTION
This PR adds the names of confirmed seminar speakers to the events page.