### PR TITLE
Add Indico link for 4/17 seminar

### DIFF
--- a/events.html
+++ b/events.html
@@ -73,7 +73,7 @@
 							and engineering. Talks are tentatively scheduled at 12pm (PDT).
 							Below is the planned agenda for 2023:
 						<ul>
-							<li>Apr 17th: Niharika Sravan (MMA)
+							<li>Apr 17th: Niharika Sravan (MMA): <a href="https://indico.cern.ch/event/1275129/">Indico details</a>
 							<li>May 8 (Neuro)
 							<li>June 12: Thea Aarrestad (HEP)
 							<li>July 10 (Distinguished)


### PR DESCRIPTION
This PR adds a link to the Indico event page for the seminar on 4/17.